### PR TITLE
feat: version control for metadata agent and intelligence agent

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -89,8 +89,8 @@ jobs:
           echo "QUOLLIO_CORE_LATEST_VERSION=$LIB_VERSION" >> $GITHUB_ENV
 
           CONTAINER_VERSION=$(echo ${GITHUB_REF##*/} | sed -E 's/^(v[0-9]+\.[0-9]+).*/\1/')
-          echo ${CONTAINER_LATEST_VERSION} is used as image tag.
-          echo "CONTAINER_LATEST_VERSION=$LIB_VERSION" >> $GITHUB_ENV
+          echo ${CONTAINER_VERSION} is used as image tag.
+          echo "CONTAINER_LATEST_VERSION=$CONTAINER_VERSION" >> $GITHUB_ENV
 
       - name: Build and push image
         uses: docker/build-push-action@v6

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -64,6 +64,9 @@ jobs:
     permissions:
       id-token: write
 
+    env:
+      REPOSITORY: "quollio-core-universal"
+
     steps:
       # Initialize
       - name: checkout
@@ -82,14 +85,20 @@ jobs:
       - name: get latest tag
         run: |
           LIB_VERSION=$(echo ${GITHUB_REF##*/} | sed 's/^v//')
+          echo ${LIB_VERSION} is used as module version.
           echo "QUOLLIO_CORE_LATEST_VERSION=$LIB_VERSION" >> $GITHUB_ENV
 
-      # Build container image and push it to ECR.
-      - name: build
-        env:
-          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          REPOSITORY: "quollio-core-universal"
-          IMAGE_TAG: latest
-        run: |
-          docker build --no-cache -t ${{ env.REGISTRY }}/${{ env.REPOSITORY }}:${{ env.IMAGE_TAG }} . -f ./Dockerfile --build-arg LIB_VERSION=${{ env.QUOLLIO_CORE_LATEST_VERSION }} --platform=linux/amd64
-          docker push ${{ env.REGISTRY }}/${{ env.REPOSITORY }}:${{ env.IMAGE_TAG }}
+          CONTAINER_VERSION=$(echo ${GITHUB_REF##*/} | sed -E 's/^(v[0-9]+\.[0-9]+).*/\1/')
+          echo ${CONTAINER_LATEST_VERSION} is used as image tag.
+          echo "CONTAINER_LATEST_VERSION=$LIB_VERSION" >> $GITHUB_ENV
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          platform: linux/amd64
+          push: true
+          tags: ${{ format('{0}/{1}:latest', steps.login-ecr.outputs.registry, env.REPOSITORY) }},${{ format('{0}/{1}:{2}', steps.login-ecr.outputs.registry, env.REPOSITORY, env.CONTAINER_LATEST_VERSION) }}
+          build-args: |
+            LIB_VERSION=${{ env.QUOLLIO_CORE_LATEST_VERSION }}


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->
Metadata agent currently refers to the latest tag of ECR container.
In this way, we'll encounter the problem caused by broken changes.
We want to fix the version of the container.


## Development notes
<!-- What have you changed? Consider adding a screenshot or GIF. -->
My image is as folllows.
- Fix the version of image.
- Minor bug fixes or updates will be updated automatically.

Attach major version tag to ECR image tag.
If the GitHub repository tag is v1.2.3, ECR image tag is v1.2

[AsIs]
Push a container into ECR with latest tag.

[Tobe]
Push a container into ECR with both latest tag and specific tag(latest repository tag).
If v0.4.10 is used as latest repository tag, image with the tag v0.4 will be pushed into ECR.

Since workflow pushes latest tag, this change doesn't influence current behavior.